### PR TITLE
Added debug, builds break on compilation failures, added failOnSemanticErrors option

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "broccoli-plugin": "^1.2.0",
     "colors": "^1.1.2",
+    "debug": "^2.1.2",
     "fs-extra": "^0.24.0",
     "glob": "^5.0.15",
     "lodash": "^3.10.1"


### PR DESCRIPTION
The TSC compiler was putting a lot of debugging output into my builds, so I added the debug package which seems to be very common in the npm ecosystem. Debugging output can now be accessed by setting DEBUG=broccoli-typescript in your environment.

I removed the try catch since broccoli already surrounds the build hook in a try catch and caught errors were being displayed twice.

The compiler plugin never failed even if there were errors. It now always fails on unrecoverable errors and can be configured to fail on semantic errors.
